### PR TITLE
Ignore nested occurrences of ignored fields

### DIFF
--- a/ignoredfieldsresponse.json
+++ b/ignoredfieldsresponse.json
@@ -1,0 +1,33 @@
+{
+    "ignoredFields": [
+        "createdAt"
+    ],
+    "tests": [
+        {
+            "name": "ignoredFieldsResponse",
+            "request": {
+                "method": "GET",
+                "url": "/users"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "id": 1,
+                        "name": "name1",
+                        "nested": {
+                            "hello": 1
+                        }
+                    },
+                    {
+                        "id": 2,
+                        "name": "name2",
+                        "nested": {
+                            "hello": 0
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/suite.go
+++ b/suite.go
@@ -317,7 +317,12 @@ func (suite TestSuite) compareObjects(obj map[string]interface{}, expectedObj ma
 		}
 	}
 
-	// Deep compare the objects and return any errors on non-ignored fields
+	// Deep compare the objects and return any errors,
+	// ignoring any errors that match an ignored field.
+	//
+	// NOTE: This approach is brittle as it assumes the
+	// github.com/go-test/deep package's Equal method
+	// continues to return errors in the expected format.
 	diffs := make([]string, 0)
 	allDiffs := deep.Equal(obj, expectedObj)
 	ignoredFieldsMatchExpr := fmt.Sprintf(`\[%s\]$`, strings.Join(suite.spec.IgnoredFields, `\]|\[`))

--- a/suite.go
+++ b/suite.go
@@ -329,13 +329,13 @@ func (suite TestSuite) compareObjects(obj map[string]interface{}, expectedObj ma
 	for _, diff := range allDiffs {
 		field, _, found := strings.Cut(diff, ":")
 		if !found {
-			return nil, fmt.Errorf("invalid diff %s returned by deep.Equal", diff)
+			return diffs, fmt.Errorf("invalid diff %s returned by deep.Equal", diff)
 		}
 
 		// ignore errors that match an ignored field
 		matched, err := regexp.MatchString(ignoredFieldsMatchExpr, field)
 		if err != nil {
-			return nil, err
+			return diffs, err
 		}
 
 		if !matched {

--- a/suite_test.go
+++ b/suite_test.go
@@ -59,3 +59,23 @@ func TestListResponse(t *testing.T) {
 		}
 	}
 }
+
+func TestIgnoredFields(t *testing.T) {
+	mockClient := MockHttpClient{}
+	mockClient.StatusCode = 200
+	mockClient.Body = "[{\"id\": 1, \"name\": \"name1\", \"nested\": {\"hello\": 1, \"createdAt\": \"2023-04-05T12:38:54.038Z\"}, \"createdAt\": \"2023-04-05T12:38:54.038Z\"},{\"id\": 2,\"name\": \"name2\", \"nested\": {\"hello\": 0, \"createdAt\": \"2023-04-05T12:38:54.036226Z\"}, \"createdAt\": \"2023-04-05T12:38:54.036226Z\"}]"
+	results, _ := ExecuteSuite(RunConfig{
+		BaseUrl:       "",
+		CustomHeaders: nil,
+		HttpClient:    &mockClient,
+	}, "ignoredfieldsresponse.json", true)
+
+	if len(results.Passed) == 0 {
+		t.Errorf("All tests should have passed.\n")
+	}
+	if len(results.Failed) > 0 {
+		for _, test := range results.Failed {
+			t.Errorf("Failed test result: [%s]\n", test.Result())
+		}
+	}
+}


### PR DESCRIPTION
Reimplement IgnoredFields by ignoring diffs generated by deep.Equal on any of the fields listed in IgnoredFields so that nested occurrences of the fields are also ignored.