### PR TITLE
Update the variable template/replacement regex to match any non-space characters to support all types of variable replacements

### DIFF
--- a/suite.go
+++ b/suite.go
@@ -204,7 +204,7 @@ func (suite TestSuite) executeTest(test TestSpec, extractedFields map[string]str
 
 	// Replace any template variables in test's request url with the appropriate value
 	requestUrl := test.Request.Url
-	templateVariableRegex := regexp.MustCompile(`{{\s*[a-zA-Z0-9\.]+\s*}}`)
+	templateVariableRegex := regexp.MustCompile(`{{\s*[^\s]+\s*}}`)
 	templateVariables := templateVariableRegex.FindAll([]byte(requestUrl), -1)
 	for _, templateVariable := range templateVariables {
 		templateVal := getTemplateValIfPresent(string(templateVariable), extractedFields)


### PR DESCRIPTION
The current variable replacement regex fails to parse replacements like:
```go
{{ myArr[3].id }}
```
because the array index isn't matched. This PR updates the regex to match any one or more non-space characters.