### PR TITLE
Add support for a 'skip' attribute on individual tests and test suites

### DIFF
--- a/run.go
+++ b/run.go
@@ -81,10 +81,12 @@ func Run(runConfigFilename string, testDir string) (bool, error) {
 	total := 0
 	numPassed := 0
 	numFailed := 0
+	numSkipped := 0
 	for _, result := range results {
 		total += result.TotalTests
 		numFailed += len(result.Failed)
 		numPassed += len(result.Passed)
+		numSkipped += len(result.Skipped)
 		if len(result.Failed) == 0 {
 			continue
 		}
@@ -93,7 +95,7 @@ func Run(runConfigFilename string, testDir string) (bool, error) {
 			fmt.Print(failed.Result())
 		}
 	}
-	fmt.Printf("\nTotal: %d\nPassed: %d\nFailed: %d\nDuration: %s\n", total, numPassed, numFailed, execDuration)
+	fmt.Printf("\nTotal: %d\nPassed: %d\nFailed: %d\nSkipped: %d\nDuration: %s\n", total, numPassed, numFailed, numSkipped, execDuration)
 	if numFailed > 0 {
 		return false, nil
 	}


### PR DESCRIPTION
This PR adds support for a boolean `skip` attribute to individual tests and test suites. If set to true, the attribute skips the given test/suite (defaults to false).

Skipping a test suite:
```json
{
   "skip": true,
   "tests": [
      ...
   ]
}
```

Skipping an individual test:
```json
{
   "tests": [
      {
         "name": "myTest",
         "skip": true,
         ...
      }
   ]
}
```