### PR TITLE
Update ignored fields matching logic

### DIFF
--- a/suite.go
+++ b/suite.go
@@ -362,7 +362,11 @@ func (suite TestSuite) compareObjects(obj map[string]interface{}, expectedObj ma
 	// github.com/go-test/deep package's Equal method
 	// continues to return errors in the expected format.
 	deepLibDiffs := deep.Equal(obj, expectedObj)
-	ignoredFieldsMatchRegExp := regexp.MustCompile(fmt.Sprintf(`\[%s\]$`, strings.Join(suite.spec.IgnoredFields, `\]$|\[`)))
+	ignoredFieldsMatchRegExp, err := regexp.Compile(fmt.Sprintf(`\[%s\]$`, strings.Join(suite.spec.IgnoredFields, `\]$|\[`)))
+	if err != nil {
+		return diffs, errors.Wrap(err, "invalid ignored fields regexp")
+	}
+
 	for _, diff := range deepLibDiffs {
 		field, _, found := strings.Cut(diff, ": ")
 		if !found {

--- a/suite.go
+++ b/suite.go
@@ -364,7 +364,7 @@ func (suite TestSuite) compareObjects(obj map[string]interface{}, expectedObj ma
 	deepLibDiffs := deep.Equal(obj, expectedObj)
 	ignoredFieldsMatchExpr := fmt.Sprintf(`\[%s\]$`, strings.Join(suite.spec.IgnoredFields, `\]|\[`))
 	for _, diff := range deepLibDiffs {
-		field, _, found := strings.Cut(diff, ":")
+		field, _, found := strings.Cut(diff, ": ")
 		if !found {
 			return diffs, fmt.Errorf("invalid diff %s returned by deep.Equal", diff)
 		}

--- a/suite.go
+++ b/suite.go
@@ -362,20 +362,15 @@ func (suite TestSuite) compareObjects(obj map[string]interface{}, expectedObj ma
 	// github.com/go-test/deep package's Equal method
 	// continues to return errors in the expected format.
 	deepLibDiffs := deep.Equal(obj, expectedObj)
-	ignoredFieldsMatchExpr := fmt.Sprintf(`\[%s\]$`, strings.Join(suite.spec.IgnoredFields, `\]|\[`))
+	ignoredFieldsMatchRegExp := regexp.MustCompile(fmt.Sprintf(`\[%s\]$`, strings.Join(suite.spec.IgnoredFields, `\]$|\[`)))
 	for _, diff := range deepLibDiffs {
 		field, _, found := strings.Cut(diff, ": ")
 		if !found {
-			return diffs, fmt.Errorf("invalid diff %s returned by deep.Equal", diff)
+			return diffs, fmt.Errorf("unexpectedly formatted diff %s returned by deep.Equal", diff)
 		}
 
-		// ignore errors that match an ignored field
-		matched, err := regexp.MatchString(ignoredFieldsMatchExpr, field)
-		if err != nil {
-			return diffs, err
-		}
-
-		if !matched {
+		// Only register errors that don't match an ignored field
+		if !ignoredFieldsMatchRegExp.Match([]byte(field)) {
 			diffs = append(diffs, diff)
 		}
 	}


### PR DESCRIPTION
This PR updates the ignored fields matching logic to:
(1) be agnostic of colons (:) in field names
(2) only match (and ignore) error strings containing an ignored field **at the end** of the string.