### PR TITLE
Add support for running specific test suite(s)

### DIFF
--- a/cmd/apirunner/main.go
+++ b/cmd/apirunner/main.go
@@ -18,22 +18,33 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/warrant-dev/apirunner"
 )
 
 func main() {
-	if len(os.Args) < 2 || len(os.Args) > 3 {
+	if len(os.Args) < 2 || len(os.Args) > 4 {
 		fmt.Printf("Invalid args")
 		os.Exit(1)
 	}
 	testDir := os.Args[1]
-	configFile := filepath.Join(testDir, "apirunner.conf")
-	if len(os.Args) == 3 {
-		// If configFile passed in, use that
-		configFile = os.Args[2]
+	testFilenameMatchRegex := regexp.MustCompile(".*")
+	if len(os.Args) > 2 {
+		var err error
+		testFilenameMatchRegex, err = regexp.Compile(os.Args[2])
+		if err != nil {
+			fmt.Printf("Invalid test name match regex: %v\n", err)
+			os.Exit(1)
+		}
 	}
-	passed, err := apirunner.Run(configFile, testDir)
+
+	configFile := filepath.Join(testDir, "apirunner.conf")
+	if len(os.Args) == 4 {
+		// If configFile passed in, use that
+		configFile = os.Args[3]
+	}
+	passed, err := apirunner.Run(configFile, testDir, testFilenameMatchRegex)
 	if err != nil {
 		fmt.Printf("Error executing tests: %v\n", err)
 		os.Exit(1)

--- a/run.go
+++ b/run.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -33,8 +34,8 @@ type RunConfig struct {
 	HttpClient    HttpClient
 }
 
-// Execute all test files in 'testDir'. Returns true if all tests pass, false otherwise (including on err)
-func Run(runConfigFilename string, testDir string) (bool, error) {
+// Run executes all test files in 'testDir'. Returns true if all tests pass, false otherwise (including on err)
+func Run(runConfigFilename string, testDir string, testFilenameMatchRegex *regexp.Regexp) (bool, error) {
 	// Load and validate RunConfig
 	configFile, err := os.Open(runConfigFilename)
 	if err != nil {
@@ -60,7 +61,7 @@ func Run(runConfigFilename string, testDir string) (bool, error) {
 			return err
 		}
 
-		if !info.IsDir() && strings.HasSuffix(info.Name(), ".json") {
+		if !info.IsDir() && strings.HasSuffix(info.Name(), ".json") && testFilenameMatchRegex.MatchString(info.Name()) {
 			fmt.Printf("Found '%s'\n", path)
 			testFiles = append(testFiles, path)
 		}

--- a/suite.go
+++ b/suite.go
@@ -151,7 +151,7 @@ func (result TestResult) Result() string {
 	return resultString
 }
 
-// Execute a test suite and print + return results
+// ExecuteSuite executes a test suite and prints + returns the results
 func ExecuteSuite(runConfig RunConfig, testFilename string, logFailureDetails bool) (TestSuiteResult, error) {
 	// Read test suite spec
 	jsonFile, err := os.Open(testFilename)


### PR DESCRIPTION
Add support for a new cmd argument. This argument accepts any valid regex pattern/string and will use the pattern to match against test suite filenames. Only test suites matching the pattern will be run.

Run specific test suite
```bash
apirunner ./tests nameOfTheSpecificTestSuiteIWantToRun
```

Run test suites with matching substring `authz`
```bash
apirunner ./tests authz
```