### PR TITLE
Support template vars in req body + memoize nested response body fields + memoize request body fields

### DIFF
--- a/suite.go
+++ b/suite.go
@@ -241,8 +241,17 @@ func (suite TestSuite) executeTest(test TestSpec, extractedFields map[string]str
 			testErrors = append(testErrors, fmt.Sprintf("Invalid request body: %v", err))
 			return Failed(test.Name, testErrors, time.Since(start))
 		}
-		requestBody = bytes.NewBuffer(reqBodyBytes)
+
+		// Replace any template variables in test's request body with the appropriate value
+		processedRequestBody, err := templateReplace(string(reqBodyBytes), extractedFields)
+		if err != nil {
+			testErrors = append(testErrors, err.Error())
+			return Failed(test.Name, testErrors, time.Since(start))
+		}
+
+		requestBody = bytes.NewBuffer([]byte(processedRequestBody))
 	}
+
 	baseUrl := suite.config.BaseUrl
 	if suite.spec.BaseUrl != "" {
 		baseUrl = suite.spec.BaseUrl

--- a/suite.go
+++ b/suite.go
@@ -251,6 +251,11 @@ func (suite TestSuite) executeTest(test TestSpec, extractedFields map[string]int
 		}
 
 		requestBody = bytes.NewBuffer([]byte(processedRequestBody))
+
+		// Memoize request body
+		for k, v := range flatten(test.Request.Body, "", 0) {
+			extractedFields[test.Name+".request.body."+k] = v
+		}
 	}
 
 	baseUrl := suite.config.BaseUrl
@@ -470,7 +475,7 @@ func flatten(m interface{}, prefix string, level int) map[string]interface{} {
 				childM := flatten(child, prefix, level+1)
 				for k, v := range childM {
 					flattenedKey := fmt.Sprintf("[%d].%s", i, k)
-					if level == 0 {
+					if level == 0 && prefix != "" {
 						flattenedKey = fmt.Sprintf("%s.%s", prefix, flattenedKey)
 					}
 					res[flattenedKey] = v
@@ -479,14 +484,14 @@ func flatten(m interface{}, prefix string, level int) map[string]interface{} {
 				childM := flatten(child, prefix, level+1)
 				for k, v := range childM {
 					flattenedKey := fmt.Sprintf("[%d]%s", i, k)
-					if level == 0 {
+					if level == 0 && prefix != "" {
 						flattenedKey = fmt.Sprintf("%s.%s", prefix, flattenedKey)
 					}
 					res[flattenedKey] = v
 				}
 			default:
 				flattenedKey := strconv.Itoa(i)
-				if level == 0 {
+				if level == 0 && prefix != "" {
 					flattenedKey = fmt.Sprintf("%s.%s", prefix, flattenedKey)
 				}
 				res[flattenedKey] = val
@@ -499,7 +504,7 @@ func flatten(m interface{}, prefix string, level int) map[string]interface{} {
 				childM := flatten(child, prefix, level+1)
 				for k, v := range childM {
 					flattenedKey := key + "." + k
-					if level == 0 {
+					if level == 0 && prefix != "" {
 						flattenedKey = fmt.Sprintf("%s.%s", prefix, flattenedKey)
 					}
 					res[flattenedKey] = v
@@ -508,14 +513,14 @@ func flatten(m interface{}, prefix string, level int) map[string]interface{} {
 				childM := flatten(child, prefix, level+1)
 				for k, v := range childM {
 					flattenedKey := key + k
-					if level == 0 {
+					if level == 0 && prefix != "" {
 						flattenedKey = fmt.Sprintf("%s.%s", prefix, flattenedKey)
 					}
 					res[flattenedKey] = v
 				}
 			default:
 				flattenedKey := key
-				if level == 0 {
+				if level == 0 && prefix != "" {
 					flattenedKey = fmt.Sprintf("%s.%s", prefix, flattenedKey)
 				}
 				res[flattenedKey] = val


### PR DESCRIPTION
1. Adds support for template vars in req body:
```json
{
            "name": "myTest",
            "request": {
                "method": "POST",
                "url": "/my-endpoint",
                "body": {
                    "blah": "{{ anotherTest.val }}"
                }
            },
            "expectedResponse": {
                "statusCode": 200,
                "body": {
                    "blah": "{{ anotherTest.val }}"
                }
            }
}
```

2. Adds support for nested memoization
3. Adds support for memoizing request body fields
```json
{
            "name": "myTest",
            "request": {
                "method": "POST",
                "url": "/my-endpoint",
                "body": {
                    "hello": "world"
                }
            },
            "expectedResponse": {
                "statusCode": 200,
                "body": {
                    "blah": "{{ myTest.request.body.val }}"
                }
            }
}
```

Closes #8
Closes #36 